### PR TITLE
Turn all JavaScript files into ES6 modules 

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,6 +48,7 @@ module.exports = function(grunt) {
         },
         files: {
           'deps_bundle.js': ['deps.js'],
+          'build/common.js': ['common.js'],
           'build/qdsproc.js': ['qdsproc.js'],
           'build/ovsproc.js': ['ovsproc.js'],
         },
@@ -58,10 +59,8 @@ module.exports = function(grunt) {
         files: {
           'dist/qdsproc.js': ['build/qdsproc.js'],
           'dist/common.js': [
-            'common-polyfill.js',
+            'build/common.js',
             'deps_bundle.js',
-            'common-audio.js',
-            'graph.js',
           ],
           'dist/qds.js': ['qds.js'],
           'dist/ovsproc.js': ['build/ovsproc.js'],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -56,6 +56,9 @@ module.exports = function(grunt) {
     },
     uglify: {
       dist: {
+        options: {
+          toplevel: true,
+        },
         files: {
           'dist/qdsproc.js': ['build/qdsproc.js'],
           'dist/common.js': [

--- a/common-audio.js
+++ b/common-audio.js
@@ -1,6 +1,4 @@
-"use strict";
-
-var setupAudio = function(procurl, procid) {
+export function setupAudio(procurl, procid) {
   var audioCtx = new (window.AudioContext || window.webkitAudioContext)({latencyHint: "playback"});
 
   var source;
@@ -114,7 +112,7 @@ var setupAudio = function(procurl, procid) {
   });
 };
 
-function setupPlayerControls(audioProc, bindata1Promise, bindata2Promise) {
+export function setupPlayerControls(audioProc, bindata1Promise, bindata2Promise) {
   function updatePlayButtonStates() {
     if (audioProc.isPlaying()) {
       document.getElementById("audio1").disabled = true;

--- a/common.js
+++ b/common.js
@@ -1,0 +1,5 @@
+import { makeFunctionGraph } from './graph.js';
+import { setupAudio, setupPlayerControls } from './common-audio.js';
+import './common-polyfill.js';
+
+export { makeFunctionGraph, setupAudio, setupPlayerControls };

--- a/graph.js
+++ b/graph.js
@@ -1,6 +1,4 @@
-"use strict";
-
-var makeFunctionGraph = function(axisid, funcid) {
+export function makeFunctionGraph(axisid, funcid) {
   var fgcanvas = document.getElementById(funcid);
   var width = fgcanvas.width;
   var height = fgcanvas.height;

--- a/ovs.html
+++ b/ovs.html
@@ -3,10 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Oversampling</title>
-  <!-- build:js common.js -->
-  <script src="common-polyfill.js"></script>
-  <script src="common-audio.js"></script>
-  <script src="graph.js"></script>
+  <!-- build:remove -->
   <script src="https://unpkg.com/audioworklet-polyfill/dist/audioworklet-polyfill.js"></script>
   <!-- /build -->
   <script src="ovs.js" type="module" ></script>

--- a/ovs.js
+++ b/ovs.js
@@ -1,4 +1,4 @@
-"use strict";
+import { makeFunctionGraph, setupAudio, setupPlayerControls } from './common.js';
 
 window.addEventListener("load", () => {
 

--- a/qds.html
+++ b/qds.html
@@ -3,13 +3,10 @@
 <head>
   <meta charset="UTF-8">
   <title>Quantization, Dithering, and Noise Shaping</title>
-  <!-- build:js common.js -->
-  <script src="common-polyfill.js"></script>
-  <script src="common-audio.js"></script>
-  <script src="graph.js"></script>
+  <!-- build:remove -->
   <script src="https://unpkg.com/audioworklet-polyfill/dist/audioworklet-polyfill.js"></script>
   <!-- /build -->
-  <script src="qds.js"></script>
+  <script type="module" src="qds.js" ></script>
 </head>
 <body>
   <!-- build:include playback_control_buttons.html -->

--- a/qds.js
+++ b/qds.js
@@ -1,4 +1,4 @@
-"use strict";
+import { makeFunctionGraph, setupAudio, setupPlayerControls } from './common.js';
 
 window.onload = () => {
   var graph = makeFunctionGraph("axiscanvas", "funccanvas");


### PR DESCRIPTION
This allows uglify to generate slightly smaller files by allowing it to rename/remove top-level symbols.