### PR TITLE
Stop caching `node_modules`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ notifications:
   email: false
 cache:
   directories:
-    - "node_modules"
+    - "$HOME/.npm"


### PR DESCRIPTION
It's better to start from a clean `node_modules` in case packages are deleted.