### PR TITLE
Don't invoke jake `all` task from `watch` setup function

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -199,7 +199,7 @@ task('all', [
   'dist/sw.js',
   'dist/install-sw.js',
   ...copied_targets,
-]);
+], () => { jake.logger.log('build complete'); });
 
 task('test', ['all'], () => {
   const engine = new eslint.CLIEngine({
@@ -224,7 +224,6 @@ task('clean', () => {
 task('default', ['all']);
 
 watchTask('watch', ['all'], function () {
-  jake.Task.all.invoke();
   this.throttle = 500;
   this.watchFiles.include(['*.html', '*.cc']);
 });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "jake": "jake",
     "build": "jake",
-    "watch": "jake watch",
+    "watch": "jake all watch",
     "clean": "jake clean",
     "start": "concurrently \"npm:watch\" \"serve dist\"",
     "test": "jake test"


### PR DESCRIPTION
Invoking it in the setup function resulted in it being always invoked. Instead, rely on the caller to first build then watch, and hence make the `watch` npm script call `jake all watch`.