### PR TITLE
Auto-create cache name based on SHA of cached files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -148,12 +148,6 @@
     },
     "overrides": [
       {
-        "files": ["sw.js"],
-        "parserOptions": {
-          "sourceType": "script"
-        }
-      },
-      {
         "files": ["Jakefile.js"],
         "env": { "node": true, "browser": false },
         "globals": {

--- a/install-sw.js
+++ b/install-sw.js
@@ -1,7 +1,7 @@
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', async () => {
     try {
-      await navigator.serviceWorker.register('sw.js');
+      await navigator.serviceWorker.register('sw.js', { type: 'module' });
     } catch (err) {
       console.warn('ServiceWorker registration failed: ', err);
     }

--- a/sw.js
+++ b/sw.js
@@ -1,27 +1,4 @@
-'use strict';
-
-const CACHE_NAME = 'jsdafx-dev';
-const urlsToCache = [
-  'common.js',
-  'index.html',
-  'install-sw.js',
-  'ovs.html',
-  'ovs.js',
-  'ovsproc.js',
-  'qds.html',
-  'qds.js',
-  'qdsproc.js',
-  'audio/unfinite_function.mp3',
-  'images/ant_logo.png',
-  'images/ovs/ns5.png',
-  'images/ovs/ns5b.png',
-  'images/ovs/ns5c.png',
-  'images/ovs/ns5d.png',
-  'images/qds/ns5.png',
-  'images/qds/ns5b.png',
-  'images/qds/ns5c.png',
-  'images/qds/ns5d.png',
-];
+import { CACHE_NAME, urlsToCache } from './build/cacheconfig.js';
 
 const fillCache = async () => {
   const cache = await caches.open(CACHE_NAME);


### PR DESCRIPTION
The list of files to cache on the client side is moved to the Jakefile  to determine a combined hash of all of them. The list and a cache name derived from the hash are then put into a module which is imported by the service worker.