### PR TITLE
Audio Filters app

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -206,10 +206,13 @@ htmlprocess('build/qds.html', 'qds.html',
   ['playback_control_buttons.html', 'build/jsdafx.css']);
 htmlprocess('build/ovs.html', 'ovs.html',
   ['playback_control_buttons.html', 'build/jsdafx.css']);
+htmlprocess('build/eq.html', 'eq.html',
+  ['playback_control_buttons.html', 'build/jsdafx.css']);
 
 htmlminify('dist/index.html', 'index.html');
 htmlminify('dist/qds.html', 'build/qds.html');
 htmlminify('dist/ovs.html', 'build/ovs.html');
+htmlminify('dist/eq.html', 'build/eq.html');
 
 emcc('build/ovsprocimpl.js', 'ovsprocimpl.cc');
 
@@ -219,12 +222,15 @@ rollup('build/common.js', 'common.js',
   ['graph.js', 'common-audio.js', 'common-polyfill.js']);
 rollup('build/qdsproc.js', 'qdsproc.js', ['baseproc.js']);
 rollup('build/ovsproc.js', 'ovsproc.js', ['baseproc.js', 'build/ovsprocimpl.js']);
+rollup('build/eqproc.js', 'eqproc.js', ['baseproc.js']);
 
 uglify('dist/qdsproc.js', 'build/qdsproc.js');
 uglify('dist/common.js', ['build/common.js', 'build/deps.js']);
 uglify('dist/qds.js', 'qds.js');
 uglify('dist/ovsproc.js', 'build/ovsproc.js');
 uglify('dist/ovs.js', 'ovs.js');
+uglify('dist/eqproc.js', 'build/eqproc.js');
+uglify('dist/eq.js', 'eq.js');
 uglify('dist/sw.js', 'build/sw.js');
 uglify('dist/install-sw.js', 'install-sw.js');
 

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -169,6 +169,9 @@ const filesToCache = [
   'dist/ovs.html',
   'dist/ovs.js',
   'dist/ovsproc.js',
+  'dist/eq.html',
+  'dist/eq.js',
+  'dist/eqproc.js',
   'dist/install-sw.js',
   ...copied_targets,
 ];

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -23,5 +23,7 @@ The audio samples are licensed are Creative Commons licences:
 
 * `unfinite_function.mp3` (function by [unfinite](https://soundcloud.com/unfinite)):
   [CC-BY-3.0]
+* `captain-pretzel_ghost-gulping.wav` (Ghost Gulping (Paper Mario 64) - Orchestra Arrangement by [Captain Pretzel](https://soundcloud.com/captain-pretzel)):
+  [CC-BY-3.0]
 
 [CC-BY-3.0]: https://creativecommons.org/licenses/by/3.0/

--- a/common-audio.js
+++ b/common-audio.js
@@ -113,6 +113,8 @@ export async function setupAudio(procurl, procid) {
     getFrequencyDomainData: getFrequencyDomainData,
     frequencies: frequencies,
     proc: proc,
+    get currentTime() { return audioCtx.currentTime; },
+    get sampleRate() { return audioCtx.sampleRate; },
   };
 }
 

--- a/eq.html
+++ b/eq.html
@@ -97,9 +97,14 @@
       be processed.
     </p>
     <p>
-      Predefined music signal is licensed under
+      Predefined music signal "Funk" is licensed under
       <a href="https://creativecommons.org/licenses/by/3.0/">CC-BY-3.0</a> by
       <a href="https://soundcloud.com/unfinite">unfinite</a>.
+    </p>
+    <p>
+      Predefined music signal "Orchestra" is licensed under
+      <a href="https://creativecommons.org/licenses/by/3.0/">CC-BY-3.0</a> by
+      <a href="https://soundcloud.com/captain-pretzel">Captain Pretzel</a>.
     </p>
   </div>
 </body>

--- a/eq.html
+++ b/eq.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Audio Filters</title>
+  <!-- build:remove -->
+  <script src="https://unpkg.com/audioworklet-polyfill/dist/audioworklet-polyfill.js"></script>
+  <!-- /build -->
+  <!-- build:css inline build/jsdafx.css -->
+  <link rel="stylesheet" href="jsdafx.css" />
+  <!-- /build -->
+  <script type="module" src="eq.js" ></script>
+</head>
+<body>
+  <div id="header">
+    <a href="index.html">jsdafx</a>
+    <a href="https://www.hsu-hh.de/ant"><img src="images/ant_logo.png" id="logo"></a>
+  </div>
+  <div id="content">
+    <h1>Audio Filters</h1>
+    <!-- build:include playback_control_buttons.html -->
+    <script id="_playback_controls">
+    window.fetch("playback_control_buttons.html").then(
+      (response) => response.text()
+    ).then((txt) => {
+      ctrls = document.createElement('template');
+      ctrls.innerHTML = txt;
+      scriptElem = document.getElementById("_playback_controls");
+      scriptElem.parentElement.replaceChild(ctrls.content, scriptElem);
+    });
+    </script>
+    <!-- /build -->
+    <div id="graph" style="width: 500px; height: 300px; padding-top: 10px">
+      <canvas id="funccanvas" width="500" height="300"></canvas>
+    </div>
+    <div style="width: 500px; padding-bottom: 10px; text-align: right">
+      <input id="linear" type="checkbox" /><label for="linear">linear</label>
+    </div>
+    <div class="paramentrybox">
+      <input id="bypass" type="checkbox" /><label for="bypass">Bypass</label>
+      <select id="type">
+        <option value="lowpass">LP-20</option>
+        <option value="highpass">HP-20</option>
+        <option value="lowshelving">LowShelvingFilter</option>
+        <option value="highshelving">HighShelvingFilter</option>
+        <option value="peak">PeakFilter</option>
+      </select>
+    </div>
+    <p>
+      This script demonstrates audio effects resulting from <b>Audio Filters</b>. It is
+      designed for a first insight into the perceptual effect of filtering an audio signal.
+      Besides the different filter functions and their acoustical effect the script offers
+      a first insight into the logarithmic behavior of loudness and frequency resolution of
+      our human acoustical perception.
+    </p>
+    <p>
+      The following filter types can be set in the lower part of the user interface; their
+      parameters can be controlled by dragging the red dot(s) in the frequency response graph.
+    </p>
+    <ul>
+      <li> <b>Low-/High-pass filter</b> (LP/HP) with control parameter
+        <ul>
+          <li>cut-off frequency</li>
+          <li>all frequencies above (LP) or below (HP) the cut-off frequency are attenuated
+            according to the shown frequency response
+          </li>
+        </ul>
+      </li>
+      <li><b>Low/High-frequency shelving filter</b> (LFS/HFS) with control parameters
+        <ul>
+          <li>cut-off frequency fc</li>
+          <li>boost/cut</li>
+          <li>all frequencies below (LFS) or above (HFS) the cut-off frequency are
+            boosted/cut according to the selected boost/cut
+          </li>
+        </ul>
+      </li>
+      <li><b>Peak filter</b> with control parameters
+        <ul>
+          <li>center frequency fc</li>
+          <li>boost/cut</li>
+          <li> Q-factor Q=fb/fc, which controls the bandwidth fb of the boost/cut around
+            the adjusted center frequency fc. Lower Q-factor means wider bandwidth.
+          </li>
+          <li>the peak filter boosts/cuts the center frequency with a bandwidth adjusted
+            by the Q-factor.
+          </li>
+        </ul>
+      </li>
+    </ul>
+    <p>The center window shows the frequency response (filter gain versus frequency) of
+      the selected filter functions. You can choose between a linear and a logarithmic
+      frequency axis.
+    </p>
+    <p>
+      You can choose between two predefined audio signals or your own local audio file to
+      be processed.
+    </p>
+    <p>
+      Predefined music signal is licensed under
+      <a href="https://creativecommons.org/licenses/by/3.0/">CC-BY-3.0</a> by
+      <a href="https://soundcloud.com/unfinite">unfinite</a>.
+    </p>
+  </div>
+</body>
+</html>

--- a/eq.js
+++ b/eq.js
@@ -4,7 +4,8 @@ window.addEventListener('load', async () => {
   const audioProc = await setupAudio('eqproc.js', 'eq-processor');
 
   setupPlayerControls(audioProc, [
-    { type: 'remote', label: 'Music', url: 'audio/unfinite_function.mp3' },
+    { type: 'remote', label: 'Funk', url: 'audio/unfinite_function.mp3' },
+    { type: 'remote', label: 'Orchestra', url: 'audio/captain-pretzel_ghost-gulping.wav' },
   ]);
 
   let omegaC = 1;

--- a/eq.js
+++ b/eq.js
@@ -1,0 +1,161 @@
+import { FunctionGraph, setupAudio, setupPlayerControls } from './common.js';
+
+window.addEventListener('load', async () => {
+  const audioProc = await setupAudio('eqproc.js', 'eq-processor');
+
+  setupPlayerControls(audioProc, [
+    { type: 'remote', label: 'Music', url: 'audio/unfinite_function.mp3' },
+  ]);
+
+  let omegaC = 1;
+  let gain = 1;
+  let Q = 1;
+  audioProc.proc.type = 'lowpass';
+  audioProc.proc.bypass = false;
+  audioProc.proc.parameters.get('omegaC').value = omegaC;
+  audioProc.proc.parameters.get('gain').value = gain;
+  audioProc.proc.parameters.get('Q').value = Q;
+
+  const graph = new FunctionGraph(document.getElementById('funccanvas'));
+  graph.xlim = [20, 20000];
+  graph.ylim = [-20, 20];
+
+  const cutoffMarkers = () => [[omegaC/2/Math.PI*audioProc.sampleRate, -3]];
+  const shelvingMarkers = () => [[
+    omegaC/2/Math.PI*audioProc.sampleRate,
+    10*Math.log10(gain >= 1 ? (1 + gain*gain) / 2 : 2 / (1 + 1/(gain*gain))),
+  ]];
+
+  const passGain = () => 1;
+  const shelvingGain = (m) => {
+    if (m >= 0) {
+      return Math.sqrt(2*Math.pow(10, m/10)-1);
+    }
+    return 1/Math.sqrt(2/Math.pow(10, m/10)-1);
+  };
+
+  const filterCharacteristics = {
+    lowpass: {
+      magnitudeSquared(cw, k2) {
+        const num = k2*(1 + cw);
+        return num*num/(num*num+(1-cw)*(1-cw));
+      },
+      get markers() { return cutoffMarkers(); },
+      gainFromMarker: passGain,
+    },
+    highpass: {
+      magnitudeSquared(cw, k2) {
+        const num = 1 - cw;
+        return num*num/(num*num+k2*(1 + cw)*k2*(1 + cw));
+      },
+      get markers() { return cutoffMarkers(); },
+      gainFromMarker: passGain,
+    },
+    lowshelving: {
+      magnitudeSquared(cw, k2) {
+        const a = (1-cw)*(1-cw);
+        const b = k2*k2*(1+cw)*(1+cw);
+        return gain >= 1 ? (a + gain*gain*b) / (a + b) : (a + b) / (a + b/(gain*gain));
+      },
+      get markers() { return shelvingMarkers(); },
+      gainFromMarker: shelvingGain,
+    },
+    highshelving: {
+      magnitudeSquared(cw, k2) {
+        const a = (1-cw)*(1-cw);
+        const b = k2*k2*(1+cw)*(1+cw);
+        return gain >= 1 ? (gain*gain*a + b) / (a + b) : (a + b) / (a/(gain*gain) + b);
+      },
+      get markers() { return shelvingMarkers(); },
+      gainFromMarker: shelvingGain,
+    },
+    peak: {
+      magnitudeSquared(cw, k2) {
+        const sw2 = 1 - cw*cw;
+        const a = (1-cw)*(1-cw) + k2*k2*(1+cw)*(1+cw);
+        const b = k2*sw2;
+        const Q2 = Q*Q;
+        return gain >= 1 ?
+          (a + (gain*gain/Q2-2) * b) / (a + (1/Q2-2) * b) :
+          (a + (1/Q2-2) * b) / (a + (1/(gain*gain*Q2)-2) * b);
+      },
+      get markers() {
+        const mg = 10*Math.log10(gain >= 1 ? (1 + gain*gain) / 2 : 2 / (1 + 1/(gain*gain)));
+        const k = Math.tan(omegaC/2);
+        const a = 1/(2*Q) + Math.sqrt(1+1/(4*Q*Q));
+        const fu = Math.atan(k*a) * audioProc.sampleRate/Math.PI;
+        const fl = Math.atan(k/a) * audioProc.sampleRate/Math.PI;
+        const markers = [[omegaC/2/Math.PI*audioProc.sampleRate, 20*Math.log10(gain)]];
+        if (fl >= 20) {
+          markers.push([fl, mg]);
+        }
+        if (fu <= 20000) {
+          markers.push([fu, mg]);
+        }
+        return markers;
+      },
+      gainFromMarker: (m) => Math.pow(10, m/20),
+    },
+  };
+
+  let currentCharateristic = filterCharacteristics.lowpass;
+
+  const drawTransferFunction = () => {
+    const k = Math.tan(omegaC/2);
+    const k2 = k*k;
+    const frequencies = new Float32Array(500);
+    const mag = new Float32Array(500);
+    for (let i = 0; i < frequencies.length; i++) {
+      const f = 20*Math.pow(10, i/(frequencies.length-1)*3);
+      frequencies[i] = f;
+      const omega = 2*Math.PI*f/audioProc.sampleRate;
+      mag[i] = 10*Math.log10(currentCharateristic.magnitudeSquared(Math.cos(omega), k2));
+    }
+    graph.drawData(frequencies, mag);
+    graph.drawMarkers(currentCharateristic.markers);
+  };
+
+  const smoothSetParameter = (param, value) => {
+    param.cancelAndHoldAtTime(0);
+    param.exponentialRampToValueAtTime(value, audioProc.currentTime + 0.050);
+  };
+
+  graph.addEventListener('markermove', (event) => {
+    const f = event.valX < 20 ? 20 : event.valX;
+    if (event.marker === 0) {
+      omegaC = 2*Math.PI*f/audioProc.sampleRate;
+      smoothSetParameter(audioProc.proc.parameters.get('omegaC'), omegaC);
+      gain = currentCharateristic.gainFromMarker(event.valY);
+      if (gain > 10) {
+        gain = 10;
+      } else if (gain < 0.1) {
+        gain = 0.1;
+      }
+      smoothSetParameter(audioProc.proc.parameters.get('gain'), gain);
+    } else if (event.marker === 1 | event.marker === 2) {
+      const k = Math.tan(omegaC/2);
+      const alpha = Math.tan(Math.PI*f/audioProc.sampleRate)/k;
+      Q = Math.abs(1/(alpha - 1/alpha));
+      smoothSetParameter(audioProc.proc.parameters.get('Q'), Q);
+    }
+    drawTransferFunction();
+  });
+
+  drawTransferFunction();
+
+  const cblinear = document.getElementById('linear');
+  cblinear.checked = false;
+  cblinear.onchange = function (event) {
+    graph.logx = !event.target.checked;
+    drawTransferFunction();
+  };
+
+  document.getElementById('bypass').onchange = function (event) {
+    audioProc.proc.bypass = event.target.checked;
+  };
+  document.getElementById('type').onchange = function (event) {
+    audioProc.proc.type = event.target.value;
+    currentCharateristic = filterCharacteristics[event.target.value];
+    drawTransferFunction();
+  };
+});

--- a/eqproc.js
+++ b/eqproc.js
@@ -1,0 +1,159 @@
+import { BaseProcessor } from './baseproc.js';
+
+class EQProcessor extends BaseProcessor {
+  constructor() {
+    super(['type', 'bypass']);
+
+    this.type = 'lowpass';
+    this.state = new Array(0);
+    this.a0 = 1;
+    this.a1 = 0;
+    this.a2 = 0;
+    this.b0 = 1;
+    this.b1 = 0;
+    this.b2 = 0;
+    this.bypass = false;
+  }
+
+  static get parameterDescriptors() {
+    return [
+      { name: 'omegaC', defaultValue: 1 },
+      { name: 'gain', defaultValue: 1 },
+      { name: 'Q', defaultValue: 1 },
+    ];
+  }
+
+  setChannelCount(nc) {
+    if (this.state.length !== nc) {
+      this.state = new Array(nc);
+      for (let i = 0; i < this.state.length; i++) {
+        this.state[i] = new Float32Array(2);
+      }
+    }
+  }
+
+  set type(type) {
+    this.coeffcalc = EQProcessor.coeffcalc[type];
+  }
+
+  static parameterAt(p, n) {
+    return p[p.length === 1 ? 0 : n];
+  }
+
+  process(inputs, outputs, parameters) {
+    this.setChannelCount(inputs[0].length);
+    let needParamUpdate = true;
+    if (parameters.omegaC.length === 1 && parameters.gain.length === 1 &&
+      parameters.Q.length === 1) {
+      const k = Math.tan(parameters.omegaC[0] / 2);
+      this.coeffcalc(k, parameters.gain[0], parameters.Q[0]);
+      needParamUpdate = false;
+    }
+    for (let sample = 0; sample < inputs[0][0].length; sample++) {
+      for (let channel = 0; channel < inputs[0].length; channel++) {
+        const inputData = inputs[0][channel];
+        const outputData = outputs[0][channel];
+        const state = this.state[channel];
+        if (needParamUpdate) {
+          const k = Math.tan(EQProcessor.parameterAt(parameters.omegaC, sample) / 2);
+          this.coeffcalc(k,
+            EQProcessor.parameterAt(parameters.gain, sample),
+            EQProcessor.parameterAt(parameters.Q, sample));
+        }
+        const tmp = (inputData[sample] - this.a1 * state[0] - this.a2 * state[1]) / this.a0;
+        if (this.bypass) {
+          outputData[sample] = inputData[sample];
+        } else {
+          outputData[sample] = this.b0 * tmp + this.b1 * state[0] + this.b2 * state[1];
+        }
+        state[1] = state[0];
+        state[0] = tmp;
+      }
+    }
+
+    return true;
+  }
+}
+
+EQProcessor.coeffcalc = {
+  lowpass(k) {
+    const k2 = k*k;
+    this.b0 = k2;
+    this.b1 = 2 * k2;
+    this.b2 = k2;
+    this.a0 = 1 + Math.SQRT2 * k + k2;
+    this.a1 = 2 * (k2 - 1);
+    this.a2 = 1 - Math.SQRT2 * k + k2;
+  },
+  highpass(k) {
+    const k2 = k*k;
+    this.b0 = 1;
+    this.b1 = -2;
+    this.b2 = 1;
+    this.a0 = 1 + Math.SQRT2 * k + k2;
+    this.a1 = 2 * (k2 - 1);
+    this.a2 = 1 - Math.SQRT2 * k + k2;
+  },
+  lowshelving(k, gain) {
+    const k2 = k*k; // Auxiliary variable for different filter types
+    if (gain >= 1) {
+      const v = gain;
+      this.b0 = 1 + Math.sqrt(2 * v) * k + v * k2;
+      this.b1 = 2 * (-1 + v * k2);
+      this.b2 = 1 - Math.sqrt(2 * v) * k + v * k2;
+      this.a0 = 1 + Math.SQRT2 * k + k2;
+      this.a1 = 2 * (-1 + k2);
+      this.a2 = 1 - Math.SQRT2 * k + k2;
+    } else {
+      const v = 1/gain;
+      this.b0 = 1 + Math.SQRT2 * k + k2;
+      this.b1 = 2 * (-1 + k2);
+      this.b2 = 1 - Math.SQRT2 * k + k2;
+      this.a0 = 1 + Math.sqrt(2 * v) * k + v * k2;
+      this.a1 = 2 * (-1 + v * k2);
+      this.a2 = 1 - Math.sqrt(2 * v) * k + v * k2;
+    }
+  },
+  highshelving(k, gain) {
+    const k2 = k*k;
+    if (gain >= 1) {
+      const v = gain;
+      this.b0 = v + Math.sqrt(2 * v) * k + k2;
+      this.b1 = 2 * (-v + k2);
+      this.b2 = v - Math.sqrt(2 * v) * k + k2;
+      this.a0 = 1 + Math.SQRT2 * k + k2;
+      this.a1 = 2 * (-1 + k2);
+      this.a2 = 1 - Math.SQRT2 * k + k2;
+    } else {
+      const v = 1/gain;
+      this.b0 = 1 + Math.SQRT2 * k + k2;
+      this.b1 = 2 * (-1 + k2);
+      this.b2 = 1 - Math.SQRT2 * k + k2;
+      this.a0 = v + Math.sqrt(2 * v) * k + k2;
+      this.a1 = 2 * (-v + k2);
+      this.a2 = v - Math.sqrt(2 * v) * k + k2;
+    }
+  },
+  peak(k, gain, Q) {
+    const k2 = k*k;
+    if (gain >= 1) {
+      const v = gain;
+      this.b0 = 1 + v/Q*k + k2;
+      this.b1 = 2 * (-1 + k2);
+      this.b2 = 1 - v/Q*k + k2;
+      this.a0 = 1 + 1/Q*k + k2;
+      this.a1 = 2 * (-1 + k2);
+      this.a2 = 1 - 1/Q*k + k2;
+    } else {
+      const v = 1/gain;
+      this.b0 = 1 + 1/Q*k + k2;
+      this.b1 = 2 * (-1 + k2);
+      this.b2 = 1 - 1/Q*k + k2;
+      this.a0 = 1 + v/Q*k + k2;
+      this.a1 = 2 * (-1 + k2);
+      this.a2 = 1 - v/Q*k + k2;
+    }
+  },
+};
+
+registerProcessor('eq-processor', EQProcessor);

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <ul>
     <li><a href="qds.html">Quantization, Dithering, and Noise Shaping</a></li>
     <li><a href="ovs.html">Oversampling</a></li>
+    <li><a href="eq.html">Audio Filters</a></li>
   </ul>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
+    "event-target": "^1.2.3",
     "html-minifier": "^3.5.21",
     "htmlprocessor": "^0.2.6",
     "jake": "^8.0.18",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "jake test"
   },
   "devDependencies": {
-    "audioworklet-polyfill": "^1.1.2",
+    "audioworklet-polyfill": "git+https://github.com/martinholters/audioworklet-polyfill.git#acd2cfbe0d6a387997e28b64d76b637260391014",
     "concurrently": "^4.0.1",
     "emscripten-download": "^1.0.1",
     "eslint": "^5.7.0",


### PR DESCRIPTION
Add a port of the Audio Filters (eq) applet.

This also adds `currentTime` and `sampleRate` accessors to the processing container and support for dragable makers to the function graph. Further, it switches `audioworklet-polyfill` to a preliminary version in a forked repository which contains a required (even if potentially incomplete) fix for https://github.com/GoogleChromeLabs/audioworklet-polyfill/issues/15.