### PR TITLE
Add small delay before taking screenshots

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -312,6 +312,7 @@ const takescreenhots = async () => {
       await takescreenshot('fastconv', async () => {
         const elem = await page.$('#funccanvas');
         await elem.evaluate((node) => { node.width=400; node.height=250; });
+        await page.waitForTimeout(150);
         return elem;
       });
 
@@ -339,6 +340,7 @@ const takescreenhots = async () => {
       await takescreenshot('distortion', async () => {
         const elem = await page.$('#funccanvas');
         await elem.evaluate((node) => { node.width=400; node.height=250; });
+        await page.waitForTimeout(150);
         return elem;
       });
     } finally {


### PR DESCRIPTION
There already was a delay when taking the `eq` screenshot. Hopefully this will fix the screenshot of `distortion` coming out blank every once in while. While at it, do the same to `fastconv` as it shouldn't hurt.