### PR TITLE
Add a waveform outline playback control

### DIFF
--- a/src/apptemplate.html
+++ b/src/apptemplate.html
@@ -29,6 +29,9 @@
       <input type="button" id="play" disabled="true" />
       <input type="button" id="stop" disabled="true" />
     </div>
+    <div style="width: 500px; height: 33px">
+      <canvas id="timelinecanvas" width="500" height="33"></canvas>
+    </div>
 {{{content}}}
   </div>
 </body>


### PR DESCRIPTION
This adds a waveform outline view below the player controls. Clicking on it starts playback from the clicked-at position, dragging selects a range that is looped. (This also changes playback to generally loop, i.e. loop the whole file when no range is selected.)

~~Opening as draft for now as the current playback position is not marked in any way yet, which is obviously desirable. Also, this has not been tested on touch devices or with Safari, yet.~~

Fixes #137.