### PR TITLE
Increase time to wait before taking screenshot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
           version: '3.1.13'
       - run: npm ci
       - run: npm test
+      # verify the screenshots are at least 1000 bytes; otherwise they're probably blank
+      - run: test $(stat --printf=%s dist/images/distortion.png) -gt 1000
+      - run: test $(stat --printf=%s dist/images/eq.png) -gt 1000
+      - run: test $(stat --printf=%s dist/images/fastconv.png) -gt 1000
+      - run: test $(stat --printf=%s dist/images/masking.png) -gt 1000
       - name: 'Upload artifact'
         if: matrix.node-version == '16.x'
         uses: actions/upload-artifact@v3

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -314,14 +314,14 @@ const takescreenhots = async () => {
       await takescreenshot('fastconv', async () => {
         const elem = await page.$('#funccanvas');
         await elem.evaluate((node) => { node.width=400; node.height=250; });
-        await page.waitForTimeout(150);
+        await page.waitForTimeout(250);
         return elem;
       });
 
       await takescreenshot('eq', async () => {
         const elem = await page.$('#funccanvas');
         await elem.evaluate((node) => { node.width=400; node.height=250; });
-        await page.waitForTimeout(150);
+        await page.waitForTimeout(250);
         return elem;
       });
 
@@ -342,7 +342,7 @@ const takescreenhots = async () => {
       await takescreenshot('distortion', async () => {
         const elem = await page.$('#funccanvas');
         await elem.evaluate((node) => { node.width=400; node.height=250; });
-        await page.waitForTimeout(150);
+        await page.waitForTimeout(250);
         return elem;
       });
     } finally {


### PR DESCRIPTION
Hopefully this should fix these screenshots coming out blank every once in a while like caused by the (async) scripts setting everything up not having reached the point where the canvases are drawn to when the screenshots are taken.