### PR TITLE
Robustify screenshot generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,6 @@ jobs:
           version: '3.1.13'
       - run: npm ci
       - run: npm test
-      # verify the screenshots are at least 1000 bytes; otherwise they're probably blank
-      - run: test $(stat --printf=%s dist/images/distortion.png) -gt 1000
-      - run: test $(stat --printf=%s dist/images/eq.png) -gt 1000
-      - run: test $(stat --printf=%s dist/images/fastconv.png) -gt 1000
-      - run: test $(stat --printf=%s dist/images/masking.png) -gt 1000
       - name: 'Upload artifact'
         if: matrix.node-version == '16.x'
         uses: actions/upload-artifact@v3

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -316,15 +316,20 @@ const takescreenhots = async () => {
         /* For some reason, the screenshots sometimes come out blank. In that
            case, they will be smaller than 1000 bytes. Just retry until we have
            a larger one (up to ten times) */
+        let success = false;
         for (let n=0; n < 10; n++) {
           await elem.screenshot({ path: filename });
           const sz = (await stat(filename)).size;
           if (sz > 1000) {
+            success = true;
             break;
           }
           jake.logger.error(`Warning: ${filename} too small (${sz} bytes), retrying`);
           await new Promise((resolve) => { setTimeout(resolve, 100); });
           await elem.screenshot({ path: filename });
+        }
+        if (!success) {
+          throw new Error('Failed to generate screenshot of plausible size');
         }
       };
 


### PR DESCRIPTION
* Log output from web page (to more easily diagnose problems).
* Repeat screenshot creation until the resulting size looks plausible as  a workaround for the screenshots sometimes being blank.
* Stop playing for masking.