### PR TITLE
Update call to rollup's `bundle.generate`

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -157,7 +157,7 @@ function rollup(dest, src, extradeps) {
       input: src,
       plugins: [resolve()],
     });
-    const result = await bundle.generate({ output: { format: 'es' } });
+    const result = await bundle.generate({ format: 'es' });
     return writeFile(dest, result.output[0].code, { encoding: 'utf8' });
   });
 }


### PR DESCRIPTION
Drop the obsolete `output: ...` wrapper.